### PR TITLE
Ensure users are only one word, and kick the correct person.

### DIFF
--- a/lib/cinch/plugins/timebomb.rb
+++ b/lib/cinch/plugins/timebomb.rb
@@ -18,8 +18,8 @@ module Cinch
       navi olive plum silver tan teal turquoise}
 
 
-      match /timebomb (.+)/, method: :plant_bomb
-      match /cutwire (.+)/, method: :cut_wire
+      match /timebomb ([^ ]+)/, method: :plant_bomb
+      match /cutwire ([^ ]+)/, method: :cut_wire
       self.react_on = :channel
       self.required_options = [:channels]
 
@@ -50,7 +50,7 @@ module Cinch
 
 
         timer = Timer(duration, shots: 1) do
-          m.channel.kick(m.user, "*BOOM!*")
+          m.channel.kick(whom, "*BOOM!*")
           @bombs[m.channel] = nil
         end
 


### PR DESCRIPTION
Sometimes users can leave a trailing space in their message, which leaves a message with a space in it. Stop capturing past the first word.

Additionally, kick the right person. While hilarious the first time, the code makes it clear the bot is supposed to kick the target.
